### PR TITLE
Simplify subscriptions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,7 @@ In the main module, use it as such:
 ```js
 app({
     ...
-    subscriptions: state => [
-        ...mapSubs(counterMap, counter.subscriptions(state.counter))
-    ]
+    subscriptions: state => mapSubs(counterMap, counter.subscriptions(state.counter))
 })
 ```
 


### PR DESCRIPTION
Since `mapSubs` already returns an array, it seems unnecessary to spread its result when it's the only thing being used.