### PR TITLE
use a WeakMap in place of standard Map

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Test
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: npm ci
+    - name: Run tests
+      run: npm test

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export const makeMap = (extract, merge) => {
         }
         return mappedAction
     }
-    memoizedMap.memo = new Map()
+    memoizedMap.memo = new WeakMap()
 
     let actualMap = actionStack => deepMap(memoizedMap, actionStack)
     return actualMap


### PR DESCRIPTION
Came across this library as I was about to extract a cruder version out of one of my applications' codebase's for reuse, noticed this was using standard Map to memoize the actions and decided to contribute that here instead. 

All the tests still pass after moving it to WeakMap (as they should, this is probably one of the seldom cases for a WeakMap), so this should just ensure the memoized function refs can be GC'd properly for longer lived or performance sensitive applications.

Thanks for the lib, I liked the approach better than what I had.